### PR TITLE
Add FIXME to 'no todo without ticket' rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please see [the README](./README.md) for details of added rules.
 
 ## [Unreleased]
+### Changed
+- Add FIXMEs to `no-todo-without-jira-ticket`
 
 ## [3.1.0] - 2022-07-01
 ### Added

--- a/lib/rules/no-todo-without-ticket.js
+++ b/lib/rules/no-todo-without-ticket.js
@@ -10,17 +10,17 @@ module.exports = {
     docs: {
       recommended: 'error',
       description:
-        'Comments containing TODO must reference a JIRA ticket. (e.g. ABC-1234)',
+        'Comments containing TODO or FIXME must reference a JIRA ticket. (e.g. ABC-1234)',
     },
     messages: {
-      ticket_required: `Comments containing TODO must reference a JIRA ticket. (e.g. ABC-1234)`,
+      ticket_required: `Comments containing TODO or FIXME must reference a JIRA ticket. (e.g. ABC-1234)`,
     },
 
   },
   create: function(context) {
 
      function containsTodo(text){
-      const regex = /\btodo\b/mi;
+      const regex = /\b(todo|fixme)\b/mi;
       return regex.test(text);
     }
 


### PR DESCRIPTION
As well as requiring TODO comments to have an associated JIRA ticket, require the same of FIXME comments.