### PR TITLE
Make `recommended` generic and create `recommended-angular`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Please see [the README](./README.md) for details of added rules.
 
+## Unreleased
+
+### Changed
+
+- Removed Angular-specific rules from `recommended` to make it generic; `recommended-react` now extends `recommended`
+
+### Added
+
+- `recommended-angular` extends `recommended` and adds Angular-specific rules; this is then extended by `recommended-angular-app` and `recommended-angular-lib`
+
+### Deprecated
+- `recommended-app`: prefer `recommended-angular-app`
+- `recommended-lib`: prefer `recommended-angular-lib`
+- `recommended-template`: prefer `recommended-angular-template`
+
 ## [4.8.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ Like any library, keep it updated to make sure your project follows the latest c
 
 Add `criteo` to the plugins section of your `.eslintrc` configuration file and apply:
 
-- `plugin:criteo/recommended-app` if the project is an Angular application
-- `plugin:criteo/recommended-lib` if the project is an Angular library
-- `plugin:criteo/recommended-react-app` if the project is a React application or library
+- `plugin:criteo/recommended-angular-app` if the project is an Angular application (formerly, now deprecated, `recommended-app`)
+- `plugin:criteo/recommended-angular-lib` if the project is an Angular library (formerly, now deprecated, `recommended-lib`)
+- `plugin:criteo/recommended-react-app` if the project is a React application
+- `plugin:criteo/recommended-react-lib` if the project is a React library
+- `plugin:criteo/recommended` for general-purpose rules which are included in all the above recommended configs
+- `plugin:criteo/recommended-angular-template` for Angular HTML templates (formerly, now deprecated, `recommended-template`)
 
 ```json
 {
@@ -24,12 +27,12 @@ Add `criteo` to the plugins section of your `.eslintrc` configuration file and a
   "overrides": [
     {
       "files": ["*.ts"],
-      "extends": ["plugin:criteo/recommended-app"], // or recommended-lib
+      "extends": ["plugin:criteo/recommended-angular-app"], // or recommended-react-app, recommended-angular-lib...
       [...]
     },
     {
       "files": ["*.html"],
-      "extends": ["plugin:criteo/recommended-template"],
+      "extends": ["plugin:criteo/recommended-angular-template"],
       [...]
     }
   ]

--- a/lib/configs/internal/recommended-angular-app.js
+++ b/lib/configs/internal/recommended-angular-app.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  extends: ['./recommended-angular'],
+};

--- a/lib/configs/internal/recommended-angular-lib.js
+++ b/lib/configs/internal/recommended-angular-lib.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  extends: ['./recommended-angular'],
+};

--- a/lib/configs/internal/recommended-angular-template.js
+++ b/lib/configs/internal/recommended-angular-template.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  plugins: ['@angular-eslint/template'],
+  extends: ['plugin:@angular-eslint/template/recommended'],
+  parser: '@angular-eslint/template-parser',
+  rules: {
+    '@angular-eslint/template/accessibility-alt-text': 'error',
+    '@angular-eslint/template/accessibility-elements-content': 'error',
+    '@angular-eslint/template/accessibility-label-has-associated-control': 'error',
+    '@angular-eslint/template/accessibility-valid-aria': 'error',
+    '@angular-eslint/template/no-call-expression': 'error',
+    '@angular-eslint/template/no-duplicate-attributes': 'error',
+    '@angular-eslint/template/no-positive-tabindex': 'error',
+    '@angular-eslint/template/use-track-by-function': 'error',
+  },
+};

--- a/lib/configs/internal/recommended-angular.js
+++ b/lib/configs/internal/recommended-angular.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   plugins: ['@angular-eslint', 'rxjs', 'rxjs-angular'],
-  extends: ['./configs/recommended', 'plugin:rxjs/recommended',],
+  extends: ['./recommended', 'plugin:rxjs/recommended'],
   rules: {
     '@angular-eslint/no-lifecycle-call': 'error',
     '@angular-eslint/no-pipe-impure': 'error',
@@ -12,7 +12,6 @@ module.exports = {
     'criteo/ngx-component-display': 'error',
     'criteo/ngxs-selector-array-length': 'error',
     'criteo/no-ngxs-select-decorator': 'error',
-    'criteo/no-todo-without-ticket': 'error',
     'criteo/prefer-readonly-decorators': ['error', { decorators: ['Output', 'ViewSelectSnapshot'] }],
     'criteo/until-destroy': 'error',
     'rxjs-angular/prefer-takeuntil': [

--- a/lib/configs/internal/recommended-react-app.js
+++ b/lib/configs/internal/recommended-react-app.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  extends: ['./recommended-react'],
+};

--- a/lib/configs/internal/recommended-react-lib.js
+++ b/lib/configs/internal/recommended-react-lib.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  extends: ['./recommended-react'],
+};

--- a/lib/configs/internal/recommended-react.js
+++ b/lib/configs/internal/recommended-react.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = {
-  plugins: ['simple-import-sort', 'react', 'react-hooks'],
-  extends: ['./configs/recommended', 'plugin:react/recommended'],
+  plugins: ['react', 'react-hooks', 'simple-import-sort'],
+  extends: ['./recommended', 'plugin:react/recommended'],
   rules: {
     'simple-import-sort/imports': [
       'error',

--- a/lib/configs/internal/recommended.js
+++ b/lib/configs/internal/recommended.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  plugins: ['@typescript-eslint', 'cypress', 'eslint-comments', 'no-only-tests', 'simple-import-sort'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:cypress/recommended',
+    'plugin:eslint-comments/recommended',
+  ],
+  rules: {
+    'criteo/cypress-no-force': 'error',
+    'criteo/filename': 'error',
+    'criteo/filename-match-export': ['error', { removeFromFilename: ['.actions'] }],
+    'criteo/no-null-undefined-comparison': 'error',
+    'criteo/no-todo-without-ticket': 'error',
+    'eslint-comments/disable-enable-pair': ["error", {"allowWholeFile": true}],
+    'eslint-comments/require-description': 'error',
+    'no-only-tests/no-only-tests': 'error',
+    'rxjs/finnish': ['error', { functions: false, methods: false, strict: true }],
+    'rxjs/no-unsafe-takeuntil': ['error', { alias: ['untilDestroyed'] }],
+    'simple-import-sort/exports': 'error',
+    'simple-import-sort/imports': ['error', { groups: [['^\\u0000', '^@?\\w', '^[^.]', '^\\.']] }],
+  },
+};

--- a/lib/configs/recommended-angular-app.js
+++ b/lib/configs/recommended-angular-app.js
@@ -1,9 +1,5 @@
 'use strict';
 
 module.exports = {
-  plugins: ['cypress'],
-  extends: ['./configs/recommended-angular', 'plugin:cypress/recommended'],
-  rules: {
-    'criteo/cypress-no-force': 'error',
-  },
+  extends: ['./configs/internal/recommended-angular-app'],
 };

--- a/lib/configs/recommended-angular-app.js
+++ b/lib/configs/recommended-angular-app.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  plugins: ['cypress'],
+  extends: ['./configs/recommended-angular', 'plugin:cypress/recommended'],
+  rules: {
+    'criteo/cypress-no-force': 'error',
+  },
+};

--- a/lib/configs/recommended-angular-lib.js
+++ b/lib/configs/recommended-angular-lib.js
@@ -1,6 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: ['./configs/recommended-angular'],
-  rules: {},
+  extends: ['./configs/internal/recommended-angular-lib'],
 };

--- a/lib/configs/recommended-angular-lib.js
+++ b/lib/configs/recommended-angular-lib.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  extends: ['./configs/recommended-angular'],
+  rules: {},
+};

--- a/lib/configs/recommended-angular-template.js
+++ b/lib/configs/recommended-angular-template.js
@@ -1,17 +1,5 @@
 'use strict';
 
 module.exports = {
-  plugins: ['@angular-eslint/template'],
-  extends: ['plugin:@angular-eslint/template/recommended'],
-  parser: '@angular-eslint/template-parser',
-  rules: {
-    '@angular-eslint/template/accessibility-alt-text': 'error',
-    '@angular-eslint/template/accessibility-elements-content': 'error',
-    '@angular-eslint/template/accessibility-label-has-associated-control': 'error',
-    '@angular-eslint/template/accessibility-valid-aria': 'error',
-    '@angular-eslint/template/no-call-expression': 'error',
-    '@angular-eslint/template/no-duplicate-attributes': 'error',
-    '@angular-eslint/template/no-positive-tabindex': 'error',
-    '@angular-eslint/template/use-track-by-function': 'error',
-  },
+  extends: ['./configs/internal/recommended-angular-template'],
 };

--- a/lib/configs/recommended-angular-template.js
+++ b/lib/configs/recommended-angular-template.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  plugins: ['@angular-eslint/template'],
+  extends: ['plugin:@angular-eslint/template/recommended'],
+  parser: '@angular-eslint/template-parser',
+  rules: {
+    '@angular-eslint/template/accessibility-alt-text': 'error',
+    '@angular-eslint/template/accessibility-elements-content': 'error',
+    '@angular-eslint/template/accessibility-label-has-associated-control': 'error',
+    '@angular-eslint/template/accessibility-valid-aria': 'error',
+    '@angular-eslint/template/no-call-expression': 'error',
+    '@angular-eslint/template/no-duplicate-attributes': 'error',
+    '@angular-eslint/template/no-positive-tabindex': 'error',
+    '@angular-eslint/template/use-track-by-function': 'error',
+  },
+};

--- a/lib/configs/recommended-angular.js
+++ b/lib/configs/recommended-angular.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  plugins: ['@angular-eslint', 'rxjs', 'rxjs-angular'],
+  extends: ['./configs/recommended', 'plugin:rxjs/recommended',],
+  rules: {
+    '@angular-eslint/no-lifecycle-call': 'error',
+    '@angular-eslint/no-pipe-impure': 'error',
+    '@angular-eslint/prefer-on-push-component-change-detection': 'error',
+    '@angular-eslint/relative-url-prefix': 'error',
+    '@angular-eslint/use-component-view-encapsulation': 'error',
+    'criteo/ngx-component-display': 'error',
+    'criteo/ngxs-selector-array-length': 'error',
+    'criteo/no-ngxs-select-decorator': 'error',
+    'criteo/no-todo-without-ticket': 'error',
+    'criteo/prefer-readonly-decorators': ['error', { decorators: ['Output', 'ViewSelectSnapshot'] }],
+    'criteo/until-destroy': 'error',
+    'rxjs-angular/prefer-takeuntil': [
+      'error',
+      { alias: ['untilDestroyed'], checkComplete: false, checkDecorators: ['Component'], checkDestroy: false },
+    ],
+  },
+};

--- a/lib/configs/recommended-app.js
+++ b/lib/configs/recommended-app.js
@@ -1,9 +1,8 @@
 'use strict';
 
+/**
+ * @deprecated in favour of `recommended-angular-app`
+ */
 module.exports = {
-  plugins: ['cypress'],
-  extends: ['./configs/recommended', 'plugin:cypress/recommended'],
-  rules: {
-    'criteo/cypress-no-force': 'error',
-  },
+  extends: ['./configs/recommended-angular-app'],
 };

--- a/lib/configs/recommended-app.js
+++ b/lib/configs/recommended-app.js
@@ -4,5 +4,5 @@
  * @deprecated in favour of `recommended-angular-app`
  */
 module.exports = {
-  extends: ['./configs/recommended-angular-app'],
+  extends: ['./configs/internal/recommended-angular-app'],
 };

--- a/lib/configs/recommended-lib.js
+++ b/lib/configs/recommended-lib.js
@@ -4,6 +4,6 @@
  * @deprecated in favour of `recommended-angular-app`
  */
 module.exports = {
-  extends: ['./configs/recommended-angular-lib'],
+  extends: ['./configs/internal/recommended-angular-lib'],
   rules: {},
 };

--- a/lib/configs/recommended-lib.js
+++ b/lib/configs/recommended-lib.js
@@ -1,6 +1,9 @@
 'use strict';
 
+/**
+ * @deprecated in favour of `recommended-angular-app`
+ */
 module.exports = {
-  extends: ['./configs/recommended'],
+  extends: ['./configs/recommended-angular-lib'],
   rules: {},
 };

--- a/lib/configs/recommended-react-app.js
+++ b/lib/configs/recommended-react-app.js
@@ -1,9 +1,5 @@
 'use strict';
 
 module.exports = {
-  plugins: ['cypress', 'react', 'react-hooks'],
-  extends: ['./configs/recommended-react', 'plugin:cypress/recommended'],
-  rules: {
-    'criteo/cypress-no-force': 'error',
-  },
+  extends: ['./configs/internal/recommended-react-app'],
 };

--- a/lib/configs/recommended-react-lib.js
+++ b/lib/configs/recommended-react-lib.js
@@ -1,7 +1,5 @@
 'use strict';
 
 module.exports = {
-  plugins: ['cypress', 'react', 'react-hooks'],
-  extends: ['./configs/recommended-react', 'plugin:cypress/recommended'],
-  rules: {},
+  extends: ['./configs/internal/recommended-react-lib'],
 };

--- a/lib/configs/recommended-react.js
+++ b/lib/configs/recommended-react.js
@@ -1,19 +1,15 @@
 'use strict';
 
 module.exports = {
-  plugins: ['@typescript-eslint', 'no-only-tests', 'simple-import-sort', 'react', 'react-hooks'],
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react/recommended'],
+  plugins: ['simple-import-sort', 'react', 'react-hooks'],
+  extends: ['./configs/recommended', 'plugin:react/recommended'],
   rules: {
-    'criteo/no-todo-without-ticket': 'error',
-    'no-only-tests/no-only-tests': 'error',
-    'simple-import-sort/exports': 'error',
     'simple-import-sort/imports': [
       'error',
       {
         groups: [['^\\u0000', '^react$', '^@?\\w', '^[^.]', '^\\.']],
       },
     ],
-    'criteo/cypress-no-force': 'error',
     'react/hook-use-state': 'error',
     'react/no-arrow-function-lifecycle': 'error',
     'react/no-invalid-html-attribute': 'error',

--- a/lib/configs/recommended-template.js
+++ b/lib/configs/recommended-template.js
@@ -1,17 +1,8 @@
 'use strict';
 
+/**
+ * @deprecated in favour of `recommended-angular-app`
+ */
 module.exports = {
-  plugins: ['@angular-eslint/template'],
-  extends: ['plugin:@angular-eslint/template/recommended'],
-  parser: '@angular-eslint/template-parser',
-  rules: {
-    '@angular-eslint/template/accessibility-alt-text': 'error',
-    '@angular-eslint/template/accessibility-elements-content': 'error',
-    '@angular-eslint/template/accessibility-label-has-associated-control': 'error',
-    '@angular-eslint/template/accessibility-valid-aria': 'error',
-    '@angular-eslint/template/no-call-expression': 'error',
-    '@angular-eslint/template/no-duplicate-attributes': 'error',
-    '@angular-eslint/template/no-positive-tabindex': 'error',
-    '@angular-eslint/template/use-track-by-function': 'error',
-  },
+  extends: ['./configs/recommended-angular-template'],
 };

--- a/lib/configs/recommended-template.js
+++ b/lib/configs/recommended-template.js
@@ -4,5 +4,5 @@
  * @deprecated in favour of `recommended-angular-app`
  */
 module.exports = {
-  extends: ['./configs/recommended-angular-template'],
+  extends: ['./configs/internal/recommended-angular-template'],
 };

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -1,23 +1,5 @@
 'use strict';
 
 module.exports = {
-  plugins: ['@typescript-eslint', 'eslint-comments', 'no-only-tests', 'simple-import-sort'],
-  extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:eslint-comments/recommended',
-  ],
-  rules: {
-    'criteo/filename': 'error',
-    'criteo/filename-match-export': ['error', { removeFromFilename: ['.actions'] }],
-    'criteo/no-null-undefined-comparison': 'error',
-    'criteo/no-todo-without-ticket': 'error',
-    'eslint-comments/disable-enable-pair': ["error", {"allowWholeFile": true}],
-    'eslint-comments/require-description': 'error',
-    'no-only-tests/no-only-tests': 'error',
-    'rxjs/finnish': ['error', { functions: false, methods: false, strict: true }],
-    'rxjs/no-unsafe-takeuntil': ['error', { alias: ['untilDestroyed'] }],
-    'simple-import-sort/exports': 'error',
-    'simple-import-sort/imports': ['error', { groups: [['^\\u0000', '^@?\\w', '^[^.]', '^\\.']] }],
-  },
+  extends: ['./configs/internal/recommended'],
 };

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -1,36 +1,20 @@
 'use strict';
 
 module.exports = {
-  plugins: ['@angular-eslint', '@typescript-eslint', 'eslint-comments', 'no-only-tests', 'rxjs', 'rxjs-angular', 'simple-import-sort'],
+  plugins: ['@typescript-eslint', 'eslint-comments', 'no-only-tests', 'simple-import-sort'],
   extends: [
     'eslint:recommended',
-    'plugin:@angular-eslint/recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:eslint-comments/recommended',
-    'plugin:rxjs/recommended',
   ],
   rules: {
-    '@angular-eslint/no-lifecycle-call': 'error',
-    '@angular-eslint/no-pipe-impure': 'error',
-    '@angular-eslint/prefer-on-push-component-change-detection': 'error',
-    '@angular-eslint/relative-url-prefix': 'error',
-    '@angular-eslint/use-component-view-encapsulation': 'error',
     'criteo/filename': 'error',
     'criteo/filename-match-export': ['error', { removeFromFilename: ['.actions'] }],
-    'criteo/ngx-component-display': 'error',
-    'criteo/ngxs-selector-array-length': 'error',
-    'criteo/no-ngxs-select-decorator': 'error',
     'criteo/no-null-undefined-comparison': 'error',
     'criteo/no-todo-without-ticket': 'error',
-    'criteo/prefer-readonly-decorators': 'error',
-    'criteo/until-destroy': 'error',
     'eslint-comments/disable-enable-pair': ["error", {"allowWholeFile": true}],
     'eslint-comments/require-description': 'error',
     'no-only-tests/no-only-tests': 'error',
-    'rxjs-angular/prefer-takeuntil': [
-      'error',
-      { alias: ['untilDestroyed'], checkComplete: false, checkDecorators: ['Component'], checkDestroy: false },
-    ],
     'rxjs/finnish': ['error', { functions: false, methods: false, strict: true }],
     'rxjs/no-unsafe-takeuntil': ['error', { alias: ['untilDestroyed'] }],
     'simple-import-sort/exports': 'error',

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,20 @@
 'use strict';
 
-const recommendedApp = require('./configs/recommended-app.js');
-const recommendedReactApp = require('./configs/recommended-react-app.js');
-const recommendedLib = require('./configs/recommended-lib.js');
-const recommendedTemplate = require('./configs/recommended-template.js');
 const requireIndex = require('requireindex');
 
 module.exports = {
-  configs: {
-    'recommended-app': recommendedApp,
-    'recommended-react-app': recommendedReactApp,
-    'recommended-lib': recommendedLib,
-    'recommended-template': recommendedTemplate,
-  },
+  configs: requireIndex(
+    __dirname + '/configs',
+    [
+      'recommended',
+      'recommended-angular-app',
+      'recommended-angular-lib',
+      'recommended-angular-template',
+      'recommended-app',
+      'recommended-lib',
+      'recommended-react-app',
+      'recommended-react-lib',
+      'recommended-template',
+    ]),
   rules: requireIndex(__dirname + '/rules'),
 };

--- a/lib/rules/prefer-readonly-decorators.js
+++ b/lib/rules/prefer-readonly-decorators.js
@@ -27,7 +27,7 @@ module.exports = {
 
   create(context) {
     const options = context.options[0] || {};
-    const decorators = new Set(options.decorators || ['Output', 'ViewSelectSnapshot']);
+    const decorators = new Set(options.decorators);
 
     const check = function (node) {
       if (decorators.has(node.expression.callee.name) && !node.parent.readonly) {


### PR DESCRIPTION
When we first created the plugin, we only really thought of Angular apps at Criteo. Later, new configs were added for React, but `recommended`, `recommended-app`, `recommended-lib` and `recommended-template` remained Angular-specific. This commit aims to change that by creating new config files with Angular in the name. To avoid breaking changes, `recommended-app`, `recommended-lib` and `recommended-template` are still available, but are deprecated in favour of the Angular-specific names.