### PR TITLE
Fix 'No Spreading Accumulators' Rule for Multiple Spreads

### DIFF
--- a/lib/rules/no-spreading-accumulators.js
+++ b/lib/rules/no-spreading-accumulators.js
@@ -24,6 +24,7 @@ module.exports = {
           _source: null,
           getNodeText(node) {
             if (this._source == null) this._source = context.getSourceCode().text;
+            if (node == null) return null;
             return this._source.slice(node.range[0], node.range[1]);
           },
         };
@@ -49,28 +50,29 @@ module.exports = {
         const expression = arrowFn.body;
         if (!expression) return;
 
-        const shouldReport = spreadNode => {
-          if (!isSpreadNode(spreadNode)) return false;
-
-          const spreadName = spreadNode.argument.name;
-          const isAccumulatorBeingSpread = spreadName === arrowFnFirstArgName;
-          return isAccumulatorBeingSpread;
-        };
-
         if (expression.type === 'ObjectExpression') {
           let spreadIndex = null;
+          let hasNonFirstArgumentSpread = true;
           for (let i = 0; i < expression.properties.length; i++) {
-            if (isSpreadNode(expression.properties[i])) {
-              spreadIndex = i;
-              break;
+            const prop = expression.properties[i];
+            if (isSpreadNode(prop)) {
+              const isAccumulatorBeingSpread = prop.argument.name === arrowFnFirstArgName;
+              if (isAccumulatorBeingSpread) {
+                spreadIndex = i;
+              } else {
+                hasNonFirstArgumentSpread = false;
+              }
             }
           }
           if (spreadIndex == null) return;
 
           const spreadNode = expression.properties[spreadIndex];
-          if (!shouldReport(spreadNode)) return;
+          if (!spreadNode) return;
 
           const getObjectFix = () => {
+            // if something other than the accumulator is being spread, we won't automatically fix it
+            if (!hasNonFirstArgumentSpread) return undefined;
+
             // if the spread isn't the first argument of the expression, then you can only assign to the accumulator if the entry
             // isn't already present without potentially changing behavior of the reduce
             if (spreadIndex !== 0) return undefined;
@@ -94,18 +96,27 @@ module.exports = {
           return context.report(reportConfig);
         } else if (expression.type === 'ArrayExpression') {
           let spreadIndex = null;
+          let hasNonFirstArgumentSpread = true;
           for (let i = 0; i < expression.elements.length; i++) {
-            if (isSpreadNode(expression.elements[i])) {
-              spreadIndex = i;
-              break;
+            const prop = expression.elements[i];
+            if (isSpreadNode(prop)) {
+              const isAccumulatorBeingSpread = prop.argument.name === arrowFnFirstArgName;
+              if (isAccumulatorBeingSpread) {
+                spreadIndex = i;
+              } else {
+                hasNonFirstArgumentSpread = false;
+              }
             }
           }
           if (spreadIndex == null) return;
 
           const spreadNode = expression.elements[spreadIndex];
-          if (!shouldReport(spreadNode)) return;
+          if (!spreadNode) return;
 
           const getArrayFix = () => {
+            // if something other than the accumulator is being spread, we won't automatically fix it
+            if (!hasNonFirstArgumentSpread) return undefined;
+
             // if the spread isn't the first argument of the expression, then you can only assign to the accumulator if the entry
             // isn't already present without potentially changing behavior of the reduce
             if (spreadIndex !== 0) return undefined;


### PR DESCRIPTION
For situations like below, the "fix" for the _no-spreading-accumulators_ rule will error. In this case, as with the similar list-accumulator case, there isn't a catch-all fix implemented by the rule, so this change causes the rule A) not to error and B) not to suggest a fix.
`[
  { a: 1 },
  { b: 2 },
  { c: 3, d: 4 }
].reduce((acc, item) => ({ ...acc, ...item }), {});`