### PR TITLE
fix: widen angular-eslint peer range for Angular 21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please see [the README](./README.md) for details of added rules.
 ## 6.2.1
 
 - Update `rxjs-angular/prefer-takeuntil` rule to support Angular's `takeUntilDestroyed` function
+- Widen the `angular-eslint` peer dependency range to allow Angular ESLint v21
 
 ## 6.2.0
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
     "@eslint/js": "^9.20.0",
-    "angular-eslint": "^19.1.0",
+    "angular-eslint": ">=19.1.0 <22",
     "eslint": "^9.20.1",
     "eslint-plugin-cypress": "^4.1.0",
     "eslint-plugin-no-only-tests": "^3.3.0",


### PR DESCRIPTION
context: 
Hi team
which criteo-eslint-plugin npm package version should be used inside a project which uses angular 21?
codex said the the last version as a dependency to angular 19

The latest registry version I found is eslint-plugin-criteo@6.2.1, and its changelog says v6 moved to ESLint 9. It also ships flat-config support. The catch: its peer dependency is angular-eslint@^19.1.0, while this repo is Angular 21 and should use angular-eslint@21.4.0. npm 10 rejects that combo with ERESOLVE. I forced it in a temp folder and the config did load with Angular ESLint 21, but I would not call it officially clean until Criteo widens that peer range.